### PR TITLE
Adição da quantidade máxima de arquivos de logs para 30 dias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -121,6 +121,7 @@ return [
     */
 
     'log' => env('APP_LOG', 'daily'),
+    'log_max_files' => 30,
 
     'log_level' => env('APP_LOG_LEVEL', 'debug'),
 


### PR DESCRIPTION
Mantém salvas as ações dos últimos 30 dias